### PR TITLE
27_Thymeleafを使ったReadの画面描画処理 #10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	//Apache Commons Lang
 	implementation 'org.apache.commons:commons-lang3:3.14.0'
 	//Lombok

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.controller.converter.StudentConverter;
@@ -12,8 +14,7 @@ import raisetech.student.management.data.StudentCourses;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
-@RestController
-
+@Controller
 public class StudentController {
 
   private StudentService service;
@@ -26,11 +27,13 @@ public class StudentController {
   }
 
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() {
+  public String getStudentList(Model model) {
     List<Student> students = service.searchStudentList();
     List<StudentCourses> studentCourses = service.searchStudentCourseList();
 
-    return converter.convertStudentDetails(students, studentCourses);
+    model.addAttribute("studentList", converter.convertStudentDetails(students, studentCourses));
+
+    return "studentList";
   }
 
 

--- a/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
@@ -17,7 +17,7 @@ public class StudentConverter {
       studentDetail.setStudent(student);
 
       List<StudentCourses> convertStudentCourses = studentCourses.stream()
-          .filter(studentCourse -> student.getId() == studentCourse.getStudentId())
+          .filter(studentCourse -> student.getId().equals(studentCourse.getStudentId()))
           .collect(Collectors.toList());
       studentDetail.setStudentCourses(convertStudentCourses);
       studentDetails.add(studentDetail);

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -7,13 +7,13 @@ import lombok.Setter;
 @Setter
 public class Student {
 
-  private int id;
+  private Integer id;
   private String name;
   private String kanaName;
   private String nickname;
   private String email;
   private String area;
-  private int age;
+  private Integer age;
   private String sex;
   private String remark;
   private boolean isDeleted;

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+<h1>受講生情報一覧</h1>
+<table border="1">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>名前</th>
+      <th>カナ名</th>
+      <th>ニックネーム</th>
+      <th>メールアドレス</th>
+      <th>地域</th>
+      <th>年齢</th>
+      <th>性別</th>
+      <th>備考</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail: ${studentList}">
+    <td th:text="${studentDetail.student.id}"></td>
+    <td th:text="${studentDetail.student.name}"></td>
+    <td th:text="${studentDetail.student.kanaName}"></td>
+    <td th:text="${studentDetail.student.nickname}"></td>
+    <td th:text="${studentDetail.student.email}"></td>
+    <td th:text="${studentDetail.student.area}"></td>
+    <td th:text="${studentDetail.student.age}"></td>
+    <td th:text="${studentDetail.student.age != null ? studentDetail.student.age : '年齢不明'}"></td>
+
+    <td th:text="${studentDetail.student.sex}"></td>
+    <td th:text="${studentDetail.student.remark}"></td>
+    <td>
+      <ul>
+        <li th:each="course: ${studentDetail.studentCourses}" th:text="${course.courseName}"></li>
+      </ul>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
## 実装内容
- Thymeleafを使った画面描画処理を追加
- 受講生一覧と、受講生ごとの取得コースをhttp://localhost:8080/studentListにて表示

## 動作確認
### 1. 表示された画面
<img width="2091" height="890" alt="Image" src="https://github.com/user-attachments/assets/1337e417-11b3-4403-8d30-596bdd3dbc7e" />

## 工夫した点・学んだこと
- data/student で、private Int age; にしていたら、No5 伊藤　健の年齢が SQLでは age : null だったのに、画面では「０」になっていました。しらべらた、int 型はNullが入らないとのことで、
private Int age;　→　private Integer age; に変更。    

プリミティブ型とオブジェクト型に関して再確認  

| 比較項目        | `int`（プリミティブ型）                             | `Integer`（オブジェクト型 / クラス）                      |
|-----------------|--------------------------------------------------|--------------------------------------------------|
| 型の種類        | 基本型（プリミティブ）                              | クラス型（オブジェクト）                          |
| null 許容       | ❌ できない（デフォルトは `0`）                     | ✅ できる（nullをそのまま保持）                  |
| ラッパークラス   | ❌（それ自体が基本型）                              | ✅（`int`を包むクラス）                           |
| メソッド使用     | ❌ 使えない                                         | ✅ `.compareTo()`, `.toString()` など利用可能     |
| 変換（自動）     | ✅ **オートボクシング / アンボクシング** により自動変換される | ✅ 同左              